### PR TITLE
Fix console.log from addPackage

### DIFF
--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -42,7 +42,7 @@ async function addPackage(name, repo, version, dir) {
   }
   Promise.all(promises).then(() => {
     Motoko.addPackage(name, name + '/');
-    console.log("base library loaded");
+    console.log(`Loaded motoko library "${name}"`);
     changeCodeBlock(); // from run_repl.js
   });
 }


### PR DESCRIPTION
It had the package name hard-coded in the log message, instead of using `name`.