### PR TITLE
Fix: Make right-side table of contents sticky on desktop

### DIFF
--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -48,6 +48,9 @@
 @media screen and (min-width: 1024px) {
   .toc {
     display: inline-table;
+  }
+  
+  .toc-menu {
     min-width: 10rem;
     max-width: 15rem;
     padding: 1rem 0;


### PR DESCRIPTION
Was intended to be sticky but still scrolled with content.

Works properly with pertinent CSS rules moved down a level to .toc-menu

https://forum.dfinity.org/t/site-fix-sdk-documentation-sites-right-hand-sidebar-is-not-sticky-as-intended/4997